### PR TITLE
Update Travis config with latest supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ matrix:
     - os: linux
       python: 2.7
     - os: linux
-      python: 3.4
-    - os: linux
       python: 3.5
     - os: linux
       python: 3.6
+    - os: linux
+      language: python
+      python: 3.8
+      dist: xenial
+      sudo: true
     - os: linux
       language: python
       python: 3.7
@@ -20,13 +23,13 @@ matrix:
       python: 3.6
       # Don't allow the python library to download (check if it can use an installed hunspell)
       env: SKIP_DOWNLOAD=true
-      dist: artful
+      dist: bionic
       sudo: true
 
 before_install:
   # For debug purposes
   - if [[ "$SKIP_DOWNLOAD" == "true" ]]; then sudo apt-cache search hunspell; fi
-  - if [[ "$SKIP_DOWNLOAD" == "true" ]]; then sudo apt-get install libhunspell-1.3-0 libhunspell-dev; fi
+  - if [[ "$SKIP_DOWNLOAD" == "true" ]]; then sudo apt-get install libhunspell-1.6-0 libhunspell-dev; fi
   # For debug purposes
   - python --version
 install: "python setup.py install && pip install -r requirements-test.txt"


### PR DESCRIPTION
Adds Python 3.8 to and removes 3.4 from the Travis config to test supported Python versions.

Also fixes a failing CI test by updating the test to the latest Ubuntu LTS and the available libhunspell version.